### PR TITLE
Extra step added to create a clone documentation

### DIFF
--- a/docs/developer_docs/tasks/updatekp.rst
+++ b/docs/developer_docs/tasks/updatekp.rst
@@ -83,4 +83,5 @@ Create a Clone of KP
      - ``sudo chown -R lacey-local:www-dev fresh/``
 5. Change the database in the dev/fresh/sites/default/settings.php from kp3_live to kp3_fresh. 
      - You need to use sudo to change this file.
-
+6. Change the write permission of dev/fresh/sites/default/files to be writable by all.
+     - ``sudo chmod 777 files/``


### PR DESCRIPTION
Extended the "Create a Clone of KP" section to include changing permission of a folder as the final step. Though it's a small change, it's my first change for documentation on ReadTheDocs, so I'd like for a second pair of eyes to make sure the formatting is correct 👍

<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon nothing